### PR TITLE
Fix broken parabolic snap store link

### DIFF
--- a/parabolic.html
+++ b/parabolic.html
@@ -57,7 +57,7 @@
       </a>
 
       <a class="card card-square card-project"
-        href="https://snapcraft.io/tubeconverter"
+        href="https://snapcraft.io/tube-converter"
         target="_blank">
         <img class="project-image" src="img/snapcraft.svg" alt="Snap"></img>
         <div class="project-about">


### PR DESCRIPTION
The snap link of parabolic was https://snapcraft.io/tubeconverter instead of https://snapcraft.io/tube-converter